### PR TITLE
openstack-nova: fix api bug and redmine #3706

### DIFF
--- a/packaging/openstack-nova/0005-Return-floating_ip-fixed_ip-instance_uuid-from-neutr.patch
+++ b/packaging/openstack-nova/0005-Return-floating_ip-fixed_ip-instance_uuid-from-neutr.patch
@@ -1,0 +1,73 @@
+From e95428076949c431e93a46f39e8e1a2bb30a636f Mon Sep 17 00:00:00 2001
+From: Matt Riedemann <mriedem@us.ibm.com>
+Date: Tue, 6 Jan 2015 09:11:24 -0800
+Subject: [PATCH 5/7] Return floating_ip['fixed_ip']['instance_uuid'] from
+ neutronv2 API
+
+The os-floating-ips extension translates the floating IP information
+from the network API for the response but is only checking fields based
+on what comes back from nova-network, which is using the FloatingIP
+object. The neutronv2 API returns a different set of keys for the
+instance/instance_uuid which the API extension doesn't handle and
+therefore doesn't show the associated instance id for a given floating
+IP.
+
+The network APIs should return consistent data formats so this change
+adds the expected key to fix the bug in the API extension (since the API
+extensions shouldn't have to know the implementation details of the
+network API, there are some extensions actually checking if it's the
+neutron API and parsing the result set based on that).
+
+This change will be used to backport the fix to the stable branches.
+
+The longer term fix is to convert the neutronv2 get_floating_ip* API
+methods to use nova objects which will be done as part of blueprint
+kilo-objects in a separate change.
+
+Conflicts:
+        nova/tests/unit/network/test_neutronv2.py
+
+NOTE(mriedem): The conflict is due to the test modules being
+moved in Kilo, otherwise the code is the same.
+
+Closes-Bug: #1380965
+
+Change-Id: I01df2096ced51eb9ebfd994cf8397f2fa094f6e3
+(cherry picked from commit 48c24dbb6bc1e55973dce2b8bc3e74105b0020ce)
+(cherry picked from commit d9bcfab1e9310d6fa6aa4d060bec59c741e12ca4)
+---
+ nova/network/neutronv2/api.py        | 3 +++
+ nova/tests/network/test_neutronv2.py | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/nova/network/neutronv2/api.py b/nova/network/neutronv2/api.py
+index 87512f9..4aca04d 100644
+--- a/nova/network/neutronv2/api.py
++++ b/nova/network/neutronv2/api.py
+@@ -1078,6 +1078,9 @@ class API(base_api.NetworkAPI):
+         if fip['port_id']:
+             instance_uuid = port_dict[fip['port_id']]['device_id']
+             result['instance'] = {'uuid': instance_uuid}
++            # TODO(mriedem): remove this workaround once the get_floating_ip*
++            # API methods are converted to use nova objects.
++            result['fixed_ip']['instance_uuid'] = instance_uuid
+         else:
+             result['instance'] = None
+         return result
+diff --git a/nova/tests/network/test_neutronv2.py b/nova/tests/network/test_neutronv2.py
+index 14a789d..21c7f0d 100644
+--- a/nova/tests/network/test_neutronv2.py
++++ b/nova/tests/network/test_neutronv2.py
+@@ -1863,6 +1863,9 @@ class TestNeutronv2(TestNeutronv2Base):
+                     'instance': ({'uuid': self.port_data2[idx]['device_id']}
+                                  if fip_data['port_id']
+                                  else None)}
++        if expected['instance'] is not None:
++            expected['fixed_ip']['instance_uuid'] = \
++                expected['instance']['uuid']
+         return expected
+ 
+     def _test_get_floating_ip(self, fip_data, idx=0, by_address=False):
+-- 
+1.8.3.1
+

--- a/packaging/openstack-nova/0006-libvirt-use-six.text_type-when-setting-text-node-val.patch
+++ b/packaging/openstack-nova/0006-libvirt-use-six.text_type-when-setting-text-node-val.patch
@@ -1,0 +1,67 @@
+From 1b5dd3adb158ea0ff6985fd9ccb217804de60378 Mon Sep 17 00:00:00 2001
+From: Matt Riedemann <mriedem@us.ibm.com>
+Date: Thu, 16 Oct 2014 19:59:57 -0700
+Subject: [PATCH 6/7] libvirt: use six.text_type when setting text node value
+ in guest xml
+
+Trying to spawn an instance with a unicode name using the libvirt driver
+fails with a UnicodeDecodeError because the value is cast to str().
+
+The fix is to use six.text_type for the cast.
+
+Closes-Bug: #1382318
+
+Conflicts:
+        nova/virt/libvirt/config.py
+
+Change-Id: I4628b94459a3c1e757d388916f1268884cb02038
+(cherry picked from commit 73fcf4628089dd784889062e916b80d3fc9988a2)
+(cherry picked from commit 0bda022c621ea3a6f80920ad0f3542358afd0fa4)
+---
+ nova/tests/virt/libvirt/test_config.py | 7 +++++++
+ nova/virt/libvirt/config.py            | 4 +++-
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/nova/tests/virt/libvirt/test_config.py b/nova/tests/virt/libvirt/test_config.py
+index 2cedc9c..937edb1 100644
+--- a/nova/tests/virt/libvirt/test_config.py
++++ b/nova/tests/virt/libvirt/test_config.py
+@@ -50,6 +50,13 @@ class LibvirtConfigTest(LibvirtConfigBaseTest):
+         xml = etree.tostring(root)
+         self.assertXmlEqual(xml, "<demo><foo>bar</foo></demo>")
+ 
++    def test_config_text_unicode(self):
++        obj = config.LibvirtConfigObject(root_name='demo')
++        root = obj.format_dom()
++        root.append(obj._text_node('foo', u'\xF0\x9F\x92\xA9'))
++        self.assertXmlEqual('<demo><foo>&#240;&#159;&#146;&#169;</foo></demo>',
++                            etree.tostring(root))
++
+     def test_config_parse(self):
+         inxml = "<demo><foo/></demo>"
+         obj = config.LibvirtConfigObject(root_name="demo")
+diff --git a/nova/virt/libvirt/config.py b/nova/virt/libvirt/config.py
+index 29feb8c..7c02977 100644
+--- a/nova/virt/libvirt/config.py
++++ b/nova/virt/libvirt/config.py
+@@ -25,6 +25,8 @@ helpers for populating up config object instances.
+ 
+ import time
+ 
++import six
++
+ from nova import exception
+ from nova.openstack.common import log as logging
+ from nova.openstack.common import units
+@@ -59,7 +61,7 @@ class LibvirtConfigObject(object):
+ 
+     def _text_node(self, name, value, **kwargs):
+         child = self._new_node(name, **kwargs)
+-        child.text = str(value)
++        child.text = six.text_type(value)
+         return child
+ 
+     def format_dom(self):
+-- 
+1.8.3.1
+

--- a/packaging/openstack-nova/0007-libvirt-safe_decode-domain.XMLDesc-0-for-i18n-loggin.patch
+++ b/packaging/openstack-nova/0007-libvirt-safe_decode-domain.XMLDesc-0-for-i18n-loggin.patch
@@ -1,0 +1,92 @@
+From f40f2a76b461e0d0e73d7dcaebcabfa36d49d901 Mon Sep 17 00:00:00 2001
+From: Matt Riedemann <mriedem@us.ibm.com>
+Date: Sat, 1 Nov 2014 09:33:17 -0700
+Subject: [PATCH 7/7] libvirt: safe_decode domain.XMLDesc(0) for i18n logging
+
+domain.XMLDesc(0) can return a utf-8 encoded string which will cause a
+UnicodeDecodeError when substituting the variable in the _LE unicode
+translated Message object in oslo.i18n.
+
+This change simply decodes domain.XMLDesc(0) before passing it onto the
+logging method when used with a translated message.
+
+Changes in original commit code is required because in stable/juno branch
+library oslo.utils is not used, so original commit is changed to use
+utils from nova/openstack/common instead of oslo.utils library
+
+Closes-Bug: #1388386
+
+Conflicts:
+	nova/tests/virt/libvirt/test_driver.py
+	nova/virt/libvirt/driver.py
+
+Change-Id: Id56d6564cfb15cc479e664020ae6f1c82acacb09
+(cherry picked from commit e7c5896fa5db657750a361c44105624de0859d43)
+(cherry picked from commit eb58ed4f9a1c3a3e228cb7183d2dd8c1d74fd0c2)
+---
+ nova/tests/virt/libvirt/test_driver.py | 5 ++++-
+ nova/virt/libvirt/driver.py            | 7 +++++--
+ 2 files changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/nova/tests/virt/libvirt/test_driver.py b/nova/tests/virt/libvirt/test_driver.py
+index ecd3b6c..1dc85cd 100644
+--- a/nova/tests/virt/libvirt/test_driver.py
++++ b/nova/tests/virt/libvirt/test_driver.py
+@@ -59,6 +59,7 @@ from nova.openstack.common import jsonutils
+ from nova.openstack.common import lockutils
+ from nova.openstack.common import loopingcall
+ from nova.openstack.common import processutils
++from nova.openstack.common import strutils
+ from nova.openstack.common import timeutils
+ from nova.openstack.common import units
+ from nova.openstack.common import uuidutils
+@@ -8963,7 +8964,8 @@ Active:          8381604 kB
+         lookup_mock.assert_called_once_with(instance['name'])
+ 
+     @mock.patch.object(fake_libvirt_utils, 'get_instance_path')
+-    def test_create_domain(self, mock_get_inst_path):
++    @mock.patch.object(strutils, 'safe_decode')
++    def test_create_domain(self, mock_safe_decode, mock_get_inst_path):
+         conn = libvirt_driver.LibvirtDriver(fake.FakeVirtAPI(), True)
+         mock_domain = mock.MagicMock()
+         mock_instance = mock.MagicMock()
+@@ -8975,6 +8977,7 @@ Active:          8381604 kB
+         self.assertEqual(mock_domain, domain)
+         mock_get_inst_path.assertHasCalls([mock.call(mock_instance)])
+         mock_domain.createWithFlags.assertHasCalls([mock.call(0)])
++        self.assertEqual(2, mock_safe_decode.call_count)
+ 
+     @mock.patch('nova.virt.disk.api.clean_lxc_namespace')
+     @mock.patch('nova.virt.libvirt.driver.LibvirtDriver.get_info')
+diff --git a/nova/virt/libvirt/driver.py b/nova/virt/libvirt/driver.py
+index 72c57d8..69d5bc4 100644
+--- a/nova/virt/libvirt/driver.py
++++ b/nova/virt/libvirt/driver.py
+@@ -77,6 +77,7 @@ from nova.openstack.common import jsonutils
+ from nova.openstack.common import log as logging
+ from nova.openstack.common import loopingcall
+ from nova.openstack.common import processutils
++from nova.openstack.common import strutils
+ from nova.openstack.common import timeutils
+ from nova.openstack.common import units
+ from nova.openstack.common import xmlutils
+@@ -4325,12 +4326,14 @@ class LibvirtDriver(driver.ComputeDriver):
+ 
+             if power_on:
+                 err = _LE('Error launching a defined domain with XML: %s') \
+-                          % domain.XMLDesc(0)
++                          % strutils.safe_decode(domain.XMLDesc(0),
++                                                 errors='ignore')
+                 domain.createWithFlags(launch_flags)
+ 
+             if not utils.is_neutron():
+                 err = _LE('Error enabling hairpin mode with XML: %s') \
+-                          % domain.XMLDesc(0)
++                          % strutils.safe_decode(domain.XMLDesc(0),
++                                                 errors='ignore')
+                 self._enable_hairpin(domain.XMLDesc(0))
+         except Exception:
+             with excutils.save_and_reraise_exception():
+-- 
+1.8.3.1
+

--- a/packaging/openstack-nova/openstack-nova.spec
+++ b/packaging/openstack-nova/openstack-nova.spec
@@ -7,7 +7,7 @@
 
 Name:             openstack-nova
 Version:          2014.2
-Release:          3%{?dist_eayunstack}
+Release:          4%{?dist_eayunstack}
 Summary:          OpenStack Compute (nova)
 
 Group:            Applications/System
@@ -48,6 +48,9 @@ Patch0001: 0001-remove-runtime-dep-on-python-pbr.patch
 Patch0002: 0002-Move-notification-point-to-a-better-place.patch
 Patch0003: 0003-Don-t-wait-for-an-event-on-a-resize-revert.patch
 Patch0004: 0004-Transform-IPAddress-to-string-when-creating-port.patch
+Patch0005: 0005-Return-floating_ip-fixed_ip-instance_uuid-from-neutr.patch
+Patch0006: 0006-libvirt-use-six.text_type-when-setting-text-node-val.patch
+Patch0007: 0007-libvirt-safe_decode-domain.XMLDesc-0-for-i18n-loggin.patch
 
 BuildArch:        noarch
 BuildRequires:    intltool
@@ -454,6 +457,9 @@ This package contains documentation files for nova.
 %patch0002 -p1
 %patch0003 -p1
 %patch0004 -p1
+%patch0005 -p1
+%patch0006 -p1
+%patch0007 -p1
 
 find . \( -name .gitignore -o -name .placeholder \) -delete
 
@@ -811,9 +817,16 @@ exit 0
 %endif
 
 %changelog
+
+* Thu May 21 2015 apporc <appleorchard2000@gmail.com> - 2014.2-4.eayunstack.1.0
+- add 0005-Return-floating_ip-fixed_ip-instance_uuid-from-neutr.patch
+- add 0006-libvirt-use-six.text_type-when-setting-text-node-val.patch
+- add 0007-libvirt-safe_decode-domain.XMLDesc-0-for-i18n-loggin.patch
+
 * Mon May 11 2015 apporc <appleorchard2000@gmail.com> - 2014.2-3.eayunstack.1.0
 - add 0003-Don-t-wait-for-an-event-on-a-resize-revert.patch
 - add 0004-Transform-IPAddress-to-string-when-creating-port.patch
+
 
 * Fri Oct 24 2014 Pádraig Brady <pbrady@redhat.com> - 2014.2-2
 - Fix openstack-nova-serialproxy.service to call correct binary


### PR DESCRIPTION
add 0005-Return-floating_ip-fixed_ip-instance_uuid-from-neutr.patch
add 0006-libvirt-use-six.text_type-when-setting-text-node-val.patch
add 0007-libvirt-safe_decode-domain.XMLDesc-0-for-i18n-loggin.patch

Signed-off-by: apporc appleorchard2000@gmail.com
