### PR TITLE
ceilometer: add memory monitor, 2014.2.2-3.eayunstack.1.1

### DIFF
--- a/packaging/openstack-ceilometer/0002-Add-Memory-Stats-meter-to-libvirt-inspector.patch
+++ b/packaging/openstack-ceilometer/0002-Add-Memory-Stats-meter-to-libvirt-inspector.patch
@@ -1,0 +1,155 @@
+From 7442ac2d90e39b2791ca5c1bd5ee5ec160cf0322 Mon Sep 17 00:00:00 2001
+From: kiwik-chenrui <chenrui.momo@gmail.com>
+Date: Fri, 25 Apr 2014 17:29:01 -0500
+Subject: [PATCH 1/2] Adds memory stats meter to libvirt inspector
+
+Uses libvirt 'virDomainMemoryStats' to retrive the memory
+that is used by domain, implements 'inspect_memory_usage'
+function in libvirt inspector.
+
+Change-Id: I5bf17d51d82d10d2f31b9c81583f53b81c1c5268
+Implements: blueprint libvirt-memory-utilization-inspector
+(cherry picked from commit 135961088d603a0ae1b51eb84d9dc7d62dc76476)
+---
+ ceilometer/compute/virt/libvirt/inspector.py       | 34 +++++++++++++++++++
+ .../tests/compute/virt/libvirt/test_inspector.py   | 39 ++++++++++++++++++++++
+ doc/source/measurements.rst                        |  8 ++++-
+ 3 files changed, 80 insertions(+), 1 deletion(-)
+
+diff --git a/ceilometer/compute/virt/libvirt/inspector.py b/ceilometer/compute/virt/libvirt/inspector.py
+index 0abb23d..b36a48f 100644
+--- a/ceilometer/compute/virt/libvirt/inspector.py
++++ b/ceilometer/compute/virt/libvirt/inspector.py
+@@ -18,8 +18,10 @@
+ 
+ from lxml import etree
+ from oslo.config import cfg
++from oslo.utils import units
+ import six
+ 
++from ceilometer.compute.pollsters import util
+ from ceilometer.compute.virt import inspector as virt_inspector
+ from ceilometer.openstack.common.gettextutils import _
+ from ceilometer.openstack.common import log as logging
+@@ -178,3 +180,35 @@ class LibvirtInspector(virt_inspector.Inspector):
+                                              write_bytes=block_stats[3],
+                                              errors=block_stats[4])
+             yield (disk, stats)
++
++    def inspect_memory_usage(self, instance, duration=None):
++        instance_name = util.instance_name(instance)
++        domain = self._lookup_by_name(instance_name)
++        state = domain.info()[0]
++        if state == libvirt.VIR_DOMAIN_SHUTOFF:
++            LOG.warn(_('Failed to inspect memory usage of %(instance_name)s, '
++                       'domain is in state of SHUTOFF'),
++                     {'instance_name': instance_name})
++            return
++
++        try:
++            memory_stats = domain.memoryStats()
++            if (memory_stats and
++                    memory_stats.get('available') and
++                    memory_stats.get('unused')):
++                memory_used = (memory_stats.get('available') -
++                               memory_stats.get('unused'))
++                # Stat provided from libvirt is in KB, converting it to MB.
++                memory_used = memory_used / units.Ki
++                return virt_inspector.MemoryUsageStats(usage=memory_used)
++            else:
++                LOG.warn(_('Failed to inspect memory usage of '
++                           '%(instance_name)s, can not get info from libvirt'),
++                         {'instance_name': instance_name})
++        # memoryStats might launch an exception if the method
++        # is not supported by the underlying hypervisor being
++        # used by libvirt
++        except libvirt.libvirtError as e:
++            LOG.warn(_('Failed to inspect memory usage of %(instance_name)s, '
++                       'can not get info from libvirt: %(error)s'),
++                     {'instance_name': instance_name, 'error': e})
+diff --git a/ceilometer/tests/compute/virt/libvirt/test_inspector.py b/ceilometer/tests/compute/virt/libvirt/test_inspector.py
+index 7162a1c..429cc74 100644
+--- a/ceilometer/tests/compute/virt/libvirt/test_inspector.py
++++ b/ceilometer/tests/compute/virt/libvirt/test_inspector.py
+@@ -22,6 +22,7 @@ import contextlib
+ 
+ import fixtures
+ import mock
++from oslo.utils import units
+ from oslotest import base
+ 
+ from ceilometer.compute.virt import inspector as virt_inspector
+@@ -245,6 +246,44 @@ class TestLibvirtInspection(base.BaseTestCase):
+             disks = list(self.inspector.inspect_disks(self.instance_name))
+             self.assertEqual(disks, [])
+ 
++    def test_inspect_memory_usage(self):
++        fake_memory_stats = {'available': 51200L, 'unused': 25600L}
++        connection = self.inspector.connection
++        with mock.patch.object(connection, 'lookupByName',
++                               return_value=self.domain):
++            with mock.patch.object(self.domain, 'info',
++                                   return_value=(0L, 0L, 51200L,
++                                                 2L, 999999L)):
++                with mock.patch.object(self.domain, 'memoryStats',
++                                       return_value=fake_memory_stats):
++                    memory = self.inspector.inspect_memory_usage(
++                        self.instance_name)
++                    self.assertEqual(25600L / units.Ki, memory.usage)
++
++    def test_inspect_memory_usage_with_domain_shutoff(self):
++        connection = self.inspector.connection
++        with mock.patch.object(connection, 'lookupByName',
++                               return_value=self.domain):
++            with mock.patch.object(self.domain, 'info',
++                                   return_value=(5L, 0L, 0L,
++                                                 2L, 999999L)):
++                memory = self.inspector.inspect_memory_usage(
++                    self.instance_name)
++                self.assertIsNone(memory)
++
++    def test_inspect_memory_usage_with_empty_stats(self):
++        connection = self.inspector.connection
++        with mock.patch.object(connection, 'lookupByName',
++                               return_value=self.domain):
++            with mock.patch.object(self.domain, 'info',
++                                   return_value=(0L, 0L, 51200L,
++                                                 2L, 999999L)):
++                with mock.patch.object(self.domain, 'memoryStats',
++                                       return_value={}):
++                    memory = self.inspector.inspect_memory_usage(
++                        self.instance_name)
++                    self.assertIsNone(memory)
++
+ 
+ class TestLibvirtInspectionWithError(base.BaseTestCase):
+ 
+diff --git a/doc/source/measurements.rst b/doc/source/measurements.rst
+index c8ff3da..ab8cee6 100644
+--- a/doc/source/measurements.rst
++++ b/doc/source/measurements.rst
+@@ -71,7 +71,7 @@ Name                             Type*  Unit       Resource  Origin**  Support**
+ instance                         g      instance   inst ID   both      1, 2, 3, 4     Existence of instance
+ instance:<type>                  g      instance   inst ID   both      1, 2, 3, 4     Existence of instance <type> (openstack types)
+ memory                           g      MB         inst ID   n         1, 2           Volume of RAM allocated in MB
+-memory.usage                     g      MB         inst ID   p         3, 4           Volume of RAM used in MB
++memory.usage                     g      MB         inst ID   p         1, 3, 4        Volume of RAM used in MB
+ cpu                              c      ns         inst ID   p         1, 2           CPU time used
+ cpu_util                         g      %          inst ID   p         1, 2, 3, 4     Average CPU utilisation
+ vcpus                            g      vcpu       inst ID   n         1, 2           Number of VCPUs
+@@ -118,6 +118,12 @@ network.outgoing.packets.rate    g      packet/s   iface ID  p         1, 2, 3,
+   [3]: Vsphere support
+   [4]: XenAPI support
+ 
++.. note:: To enable the libvirt memory.usage supporting, you need libvirt
++   version 1.1.1+, qemu version 1.5+, and you need to prepare suitable balloon
++   driver in the image, particularly for Windows guests, most modern Linuxes
++   have it built in. The memory.usage meters can't be fetched without image
++   balloon driver.
++
+ Contributors are welcome to extend other virtualization backends' meters
+ or complete the existing ones.
+ 
+-- 
+2.1.0
+

--- a/packaging/openstack-ceilometer/0003-Add-Memory-Return-a-meaningful-value-or-raise.patch
+++ b/packaging/openstack-ceilometer/0003-Add-Memory-Return-a-meaningful-value-or-raise.patch
@@ -1,0 +1,261 @@
+From 80bc7cbf07a2b7decb4ddd5f0e09581434e179b5 Mon Sep 17 00:00:00 2001
+From: ZhiQiang Fan <aji.zqfan@gmail.com>
+Date: Mon, 17 Nov 2014 23:14:03 +0800
+Subject: [PATCH 2/2] Return a meaningful value or raise an excpetion for
+ libvirt
+
+Currently, there are some cases libvirt cannot inspect instance's memory
+usage, and it is a normal behavior so libvirt just logs messages and
+returns None. However, memory pollster doesn't check return value, so
+AttributeError will be raised in such case, which leading to unnecessary
+exception log messages in every cycle and for each instance, this will
+bother cloud operator.
+
+This patch uses virt.inspector exceptions for libvirt, so when there is no
+valid value can be returned, we raise an exception, pollsters can catch
+those exceptions and log proper messages. Since all of them are non-fatal
+exception, log level is set to warn, which is excatly same as previous.
+
+Note, this patch refactors some code of libvirt to suit this change.
+
+Yuanbing Chen (cybing4@gmail.com) update
+Note, this patch don't use i18n LOG(_LW),Memory usage update MB to % ,
+This PATCH Update Memory,The Other is not update
+
+Change-Id: I2c94aab90e827c75a602403d3c64fd6f67f73007
+Closes-Bug: #1393415
+(cherry picked from commit 98b43aad172c894d3c4e288e40eaa3c4f822d47f)
+
+Conflicts:
+	ceilometer/compute/pollsters/memory.py
+	ceilometer/compute/virt/libvirt/inspector.py
+	ceilometer/compute/virt/inspector.py
+	ceilometer/tests/compute/virt/libvirt/test_inspector.py
+	ceilometer/tests/compute/pollsters/test_memory.py
+---
+ ceilometer/compute/pollsters/memory.py             | 10 ++++-
+ ceilometer/compute/virt/inspector.py               |  8 ++++
+ ceilometer/compute/virt/libvirt/inspector.py       | 49 +++++++++++++---------
+ ceilometer/tests/compute/pollsters/test_memory.py  | 36 ++++++++++------
+ .../tests/compute/virt/libvirt/test_inspector.py   | 12 +++---
+ 5 files changed, 77 insertions(+), 38 deletions(-)
+
+diff --git a/ceilometer/compute/pollsters/memory.py b/ceilometer/compute/pollsters/memory.py
+index f8d8001..237d813 100644
+--- a/ceilometer/compute/pollsters/memory.py
++++ b/ceilometer/compute/pollsters/memory.py
+@@ -39,12 +39,20 @@ class MemoryUsagePollster(plugin.ComputePollster):
+                     instance,
+                     name='memory.usage',
+                     type=sample.TYPE_GAUGE,
+-                    unit='MB',
++                    unit='%',  # unit='MB',
+                     volume=memory_info.usage,
+                 )
+             except virt_inspector.InstanceNotFoundException as err:
+                 # Instance was deleted while getting samples. Ignore it.
+                 LOG.debug(_('Exception while getting samples %s'), err)
++            except virt_inspector.InstanceShutOffException as e:
++                LOG.warn(_('Instance  was shut off while '
++                           'getting samples of %(pollster)s: %(exc)s'),
++                         {'pollster': self.__class__.__name__, 'exc': e})
++            except virt_inspector.NoDataException as e:
++                LOG.warn(_('Cannot inspect data of %(pollster)s for '
++                           'non-fatal reason: %(exc)s'),
++                         {'pollster': self.__class__.__name__, 'exc': e})
+             except ceilometer.NotImplementedError:
+                 # Selected inspector does not implement this pollster.
+                 LOG.debug(_('Obtaining Memory Usage is not implemented for %s'
+diff --git a/ceilometer/compute/virt/inspector.py b/ceilometer/compute/virt/inspector.py
+index b266ef4..b4e7044 100644
+--- a/ceilometer/compute/virt/inspector.py
++++ b/ceilometer/compute/virt/inspector.py
+@@ -143,6 +143,14 @@ class InstanceNotFoundException(InspectorException):
+     pass
+ 
+ 
++class InstanceShutOffException(InspectorException):
++    pass
++
++
++class NoDataException(InspectorException):
++    pass
++
++
+ # Main virt inspector abstraction layering over the hypervisor API.
+ #
+ class Inspector(object):
+diff --git a/ceilometer/compute/virt/libvirt/inspector.py b/ceilometer/compute/virt/libvirt/inspector.py
+index b36a48f..98834cd 100644
+--- a/ceilometer/compute/virt/libvirt/inspector.py
++++ b/ceilometer/compute/virt/libvirt/inspector.py
+@@ -53,7 +53,7 @@ def retry_on_disconnect(function):
+             if (e.get_error_code() == libvirt.VIR_ERR_SYSTEM_ERROR and
+                 e.get_error_domain() in (libvirt.VIR_FROM_REMOTE,
+                                          libvirt.VIR_FROM_RPC)):
+-                LOG.debug('Connection to libvirt broken')
++                LOG.debug(_('Connection to libvirt broken'))
+                 self.connection = None
+                 return function(self, *args, **kwargs)
+             else:
+@@ -78,7 +78,7 @@ class LibvirtInspector(virt_inspector.Inspector):
+             global libvirt
+             if libvirt is None:
+                 libvirt = __import__('libvirt')
+-            LOG.debug('Connecting to libvirt: %s', self.uri)
++            LOG.debug(_('Connecting to libvirt: %s'), self.uri)
+             self.connection = libvirt.openReadOnly(self.uri)
+ 
+         return self.connection
+@@ -124,6 +124,19 @@ class LibvirtInspector(virt_inspector.Inspector):
+         dom_info = domain.info()
+         return virt_inspector.CPUStats(number=dom_info[3], time=dom_info[4])
+ 
++    def _get_domain_not_shut_off_or_raise(self, instance):
++        instance_name = util.instance_name(instance)
++        domain = self._lookup_by_name(instance_name)
++
++        state = domain.info()[0]
++        if state == libvirt.VIR_DOMAIN_SHUTOFF:
++            msg = _('Failed to inspect data of instance '
++                    '<name=%(name)s, id=%(id)s>, '
++                    'domain state is SHUTOFF.') % {
++                'name': instance_name, 'id': instance.id}
++            raise virt_inspector.InstanceShutOffException(msg)
++        return domain
++
+     def inspect_vnics(self, instance_name):
+         domain = self._lookup_by_name(instance_name)
+         state = domain.info()[0]
+@@ -183,13 +196,7 @@ class LibvirtInspector(virt_inspector.Inspector):
+ 
+     def inspect_memory_usage(self, instance, duration=None):
+         instance_name = util.instance_name(instance)
+-        domain = self._lookup_by_name(instance_name)
+-        state = domain.info()[0]
+-        if state == libvirt.VIR_DOMAIN_SHUTOFF:
+-            LOG.warn(_('Failed to inspect memory usage of %(instance_name)s, '
+-                       'domain is in state of SHUTOFF'),
+-                     {'instance_name': instance_name})
+-            return
++        domain = self._get_domain_not_shut_off_or_raise(instance)
+ 
+         try:
+             memory_stats = domain.memoryStats()
+@@ -199,16 +206,20 @@ class LibvirtInspector(virt_inspector.Inspector):
+                 memory_used = (memory_stats.get('available') -
+                                memory_stats.get('unused'))
+                 # Stat provided from libvirt is in KB, converting it to MB.
+-                memory_used = memory_used / units.Ki
++                # memory_used = memory_used / units.Ki
++                maxMemory = domain.maxMemory()
++                memory_used = float(memory_used) / float(maxMemory) * 100.0
+                 return virt_inspector.MemoryUsageStats(usage=memory_used)
+             else:
+-                LOG.warn(_('Failed to inspect memory usage of '
+-                           '%(instance_name)s, can not get info from libvirt'),
+-                         {'instance_name': instance_name})
+-        # memoryStats might launch an exception if the method
+-        # is not supported by the underlying hypervisor being
+-        # used by libvirt
++                msg = _('Failed to inspect memory usage of instance '
++                        '<name=%(name)s, id=%(id)s>, '
++                        'can not get info from libvirt.') % {
++                    'name': instance_name, 'id': instance.id}
++                raise virt_inspector.NoDataException(msg)
++        # memoryStats might launch an exception if the method is not supported
++        # by the underlying hypervisor being used by libvirt.
+         except libvirt.libvirtError as e:
+-            LOG.warn(_('Failed to inspect memory usage of %(instance_name)s, '
+-                       'can not get info from libvirt: %(error)s'),
+-                     {'instance_name': instance_name, 'error': e})
++            msg = _('Failed to inspect memory usage of %(instance_name)s, '
++                    'can not get info from libvirt: %(error)s') % {
++                'instance_name': instance_name, 'error': e}
++            raise virt_inspector.NoDataException(msg)
+diff --git a/ceilometer/tests/compute/pollsters/test_memory.py b/ceilometer/tests/compute/pollsters/test_memory.py
+index 969518e..dfa8899 100644
+--- a/ceilometer/tests/compute/pollsters/test_memory.py
++++ b/ceilometer/tests/compute/pollsters/test_memory.py
+@@ -31,24 +31,36 @@ class TestMemoryPollster(base.TestPollsterBase):
+         next_value = iter((
+             virt_inspector.MemoryUsageStats(usage=1.0),
+             virt_inspector.MemoryUsageStats(usage=2.0),
++            virt_inspector.NoDataException(),
++            virt_inspector.InstanceShutOffException(),
+         ))
+ 
+         def inspect_memory_usage(instance, duration):
+-            return next(next_value)
++            value = next(next_value)
++            if isinstance(value, virt_inspector.MemoryUsageStats):
++                return value
++            else:
++                raise value
+ 
+-        (self.inspector.
+-         inspect_memory_usage) = mock.Mock(side_effect=inspect_memory_usage)
++        self.inspector.inspect_memory_usage = mock.Mock(
++            side_effect=inspect_memory_usage)
+ 
+         mgr = manager.AgentManager()
+         pollster = memory.MemoryUsagePollster()
+ 
+-        def _verify_memory_metering(expected_memory_mb):
+-            cache = {}
+-            samples = list(pollster.get_samples(mgr, cache, [self.instance]))
+-            self.assertEqual(1, len(samples))
+-            self.assertEqual(set(['memory.usage']),
+-                             set([s.name for s in samples]))
+-            self.assertEqual(expected_memory_mb, samples[0].volume)
++        @mock.patch('ceilometer.compute.pollsters.memory.LOG')
++        def _verify_memory_metering(expected_count, expected_memory_mb, mylog):
++            samples = list(pollster.get_samples(mgr, {}, [self.instance]))
++            self.assertEqual(expected_count, len(samples))
++            if expected_count > 0:
++                self.assertEqual(set(['memory.usage']),
++                                 set([s.name for s in samples]))
++                self.assertEqual(expected_memory_mb, samples[0].volume)
++            else:
++                self.assertEqual(1, mylog.warn.call_count)
++            self.assertEqual(0, mylog.exception.call_count)
+ 
+-        _verify_memory_metering(1.0)
+-        _verify_memory_metering(2.0)
++        _verify_memory_metering(1, 1.0)
++        _verify_memory_metering(1, 2.0)
++        _verify_memory_metering(0, 0)
++        _verify_memory_metering(0, 0)
+diff --git a/ceilometer/tests/compute/virt/libvirt/test_inspector.py b/ceilometer/tests/compute/virt/libvirt/test_inspector.py
+index 429cc74..03d4aa9 100644
+--- a/ceilometer/tests/compute/virt/libvirt/test_inspector.py
++++ b/ceilometer/tests/compute/virt/libvirt/test_inspector.py
+@@ -267,9 +267,9 @@ class TestLibvirtInspection(base.BaseTestCase):
+             with mock.patch.object(self.domain, 'info',
+                                    return_value=(5L, 0L, 0L,
+                                                  2L, 999999L)):
+-                memory = self.inspector.inspect_memory_usage(
+-                    self.instance_name)
+-                self.assertIsNone(memory)
++                self.assertRaises(virt_inspector.InstanceShutOffException,
++                                  self.inspector.inspect_memory_usage,
++                                  self.instance)
+ 
+     def test_inspect_memory_usage_with_empty_stats(self):
+         connection = self.inspector.connection
+@@ -280,9 +280,9 @@ class TestLibvirtInspection(base.BaseTestCase):
+                                                  2L, 999999L)):
+                 with mock.patch.object(self.domain, 'memoryStats',
+                                        return_value={}):
+-                    memory = self.inspector.inspect_memory_usage(
+-                        self.instance_name)
+-                    self.assertIsNone(memory)
++                    self.assertRaises(virt_inspector.NoDataException,
++                                      self.inspector.inspect_memory_usage,
++                                      self.instance)
+ 
+ 
+ class TestLibvirtInspectionWithError(base.BaseTestCase):
+-- 
+2.1.0
+

--- a/packaging/openstack-ceilometer/openstack-ceilometer.spec
+++ b/packaging/openstack-ceilometer/openstack-ceilometer.spec
@@ -2,11 +2,11 @@
 %global with_doc %{!?_without_doc:1}%{?_without_doc:0}
 %global pypi_name ceilometer
 %global release_name juno
-%global dist_eayunstack .eayunstack.1.0.1
+%global dist_eayunstack .eayunstack.1.1
 
 Name:             openstack-ceilometer
 Version:          2014.2.2
-Release:          2%{?dist_eayunstack}
+Release:          3%{?dist_eayunstack}
 Summary:          OpenStack measurement collection service
 
 Group:            Applications/System
@@ -47,6 +47,8 @@ Source17:         %{name}-ipmi.service
 %endif
 
 Patch001:            0001-BUG-1433924-Fix-resource-list-error-MongoDB-Refactor.patch
+Patch002:            0002-Add-Memory-Stats-meter-to-libvirt-inspector.patch
+Patch003:            0003-Add-Memory-Return-a-meaningful-value-or-raise.patch
 
 BuildArch:        noarch
 BuildRequires:    intltool
@@ -290,6 +292,8 @@ This package contains documentation files for ceilometer.
 %prep
 %setup -q -n ceilometer-%{version}
 %patch001 -p1
+%patch002 -p1
+%patch003 -p1
 
 find . \( -name .gitignore -o -name .placeholder \) -delete
 
@@ -762,6 +766,10 @@ fi
 
 
 %changelog
+* Sat Dec 29 2015 Yuanbin Chen <cybing4@gmail.com> 2014.2.2-3.eayunstack.1.1
+- Added Memory Monitor Usage 0002-Add-Memory-Stats-meter-to-libvirt-inspector.patch
+- Added Memory Return Check Usage 0003-Add-Memory-Return-a-meaningful-value-or-raise.patch
+
 * Wed Nov 11 2015 Yuanbin Chen <cybing4@gmail.com> 2014.2.2-2.eayunstack.1.0.1
 - Fix 0001-BUG-1433924-Fix-resource-list-error-MongoDB-Refactor.patch(redmine#5305)
 


### PR DESCRIPTION
In 2014.2.2-2.eayunstack.1.0.1 package do not support memory monitor, In 2014.2.2-3.eayunstack.1.1 package add libvirt memory inspector monitor
