### PR TITLE
openstack-nova: ephermeral RBD issue when evacuating and reverting re…

### DIFF
--- a/packaging/openstack-nova/0032-network-fix-instance-cache-refresh-for-empty-list.patch
+++ b/packaging/openstack-nova/0032-network-fix-instance-cache-refresh-for-empty-list.patch
@@ -1,7 +1,7 @@
-From 6776755cc656f0b42e30e9bb00af471b40fc5c69 Mon Sep 17 00:00:00 2001
+From 48e82996a302379a5b7ebbb499cf1177f4087efd Mon Sep 17 00:00:00 2001
 From: Sahid Orentino Ferdjaoui <sahid.ferdjaoui@redhat.com>
 Date: Thu, 28 May 2015 04:31:53 -0400
-Subject: [PATCH 33/34] network: fix instance cache refresh for empty list
+Subject: [PATCH 32/36] network: fix instance cache refresh for empty list
 
 The bug introduce a race condition makes network_info as an
 empty value. When trying to refresh cache we should use data

--- a/packaging/openstack-nova/0033-fix-unicode-issue-in-vm-resuming-procedure.patch
+++ b/packaging/openstack-nova/0033-fix-unicode-issue-in-vm-resuming-procedure.patch
@@ -1,7 +1,7 @@
-From 47d9e6cf69ff0414dce9f7f891aabebdf6db1fc3 Mon Sep 17 00:00:00 2001
+From 4515802c693c7d252fcc8a64eb60053ea8416982 Mon Sep 17 00:00:00 2001
 From: apporc <appleorchard2000@gmail.com>
 Date: Wed, 9 Dec 2015 18:08:55 +0800
-Subject: [PATCH 34/34] fix unicode issue in vm resuming procedure
+Subject: [PATCH 33/36] fix unicode issue in vm resuming procedure
 
 Change-Id: Ic9143217a53f9278a05e9341a8382d96340a0737
 Signed-off-by: apporc <appleorchard2000@gmail.com>
@@ -10,10 +10,10 @@ Signed-off-by: apporc <appleorchard2000@gmail.com>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/nova/virt/libvirt/driver.py b/nova/virt/libvirt/driver.py
-index a0ff8c6..c7d2a21 100644
+index ec0b1f5..dff1636 100644
 --- a/nova/virt/libvirt/driver.py
 +++ b/nova/virt/libvirt/driver.py
-@@ -4349,7 +4349,8 @@ class LibvirtDriver(driver.ComputeDriver):
+@@ -4332,7 +4332,8 @@ class LibvirtDriver(driver.ComputeDriver):
          err = None
          try:
              if xml:

--- a/packaging/openstack-nova/0034-Fix-nova-evacuate-issues-for-RBD.patch
+++ b/packaging/openstack-nova/0034-Fix-nova-evacuate-issues-for-RBD.patch
@@ -1,0 +1,149 @@
+From feb1bd5cd0124f0891cdec4e952920794854ca46 Mon Sep 17 00:00:00 2001
+From: Fei Long Wang <flwang@catalyst.net.nz>
+Date: Tue, 16 Sep 2014 15:43:37 +1200
+Subject: [PATCH 34/36] Fix nova evacuate issues for RBD
+
+For RBD scenario, there are some issues in Nova code
+now against evacuate function:
+
+1. Based on current implementation, nova evacuate and
+nova rebuild are sharing some code. When user enables
+the on_shared_storage option for nova evacuate, nova
+will check if the instance path is accessible. For
+the RBD scenario, the volume(block) is shared between
+different hosts, though the path isn't shared at the
+filesystem level. This patch fixes this issue and adds
+test cases for that.
+
+2. Missing the 'recreate' parameter for rebuild method.
+Though the libvirt driver doesn't implement rebuild
+method(only Ironic driver implements it), but we really
+need to set 'recreate' in kwargs so it gets passed to
+_rebuild_default_impl so we don't call driver.destroy
+on evacuate for shared filesystem/block storage cases.
+It is fixed in this patch and test case is added as well.
+
+Closes-Bug: 1249319
+Closes-Bug: 1340411
+
+Change-Id: Idc8c45b055e986cf85730235d5d25777632ad1c1
+---
+ nova/compute/manager.py                |  3 ++-
+ nova/tests/compute/test_compute_mgr.py | 44 ++++++++++++++++++++++++++++++++++
+ nova/tests/virt/libvirt/test_driver.py | 11 +++++++++
+ nova/virt/libvirt/driver.py            |  8 ++++++-
+ 4 files changed, 64 insertions(+), 2 deletions(-)
+
+diff --git a/nova/compute/manager.py b/nova/compute/manager.py
+index 8a23ea0..b6d8436 100644
+--- a/nova/compute/manager.py
++++ b/nova/compute/manager.py
+@@ -2823,7 +2823,8 @@ class ComputeManager(manager.Manager):
+                 attach_block_devices=self._prep_block_device,
+                 block_device_info=block_device_info,
+                 network_info=network_info,
+-                preserve_ephemeral=preserve_ephemeral)
++                preserve_ephemeral=preserve_ephemeral,
++                recreate=recreate)
+             try:
+                 self.driver.rebuild(**kwargs)
+             except NotImplementedError:
+diff --git a/nova/tests/compute/test_compute_mgr.py b/nova/tests/compute/test_compute_mgr.py
+index 0a148e4..b4fa1b6 100644
+--- a/nova/tests/compute/test_compute_mgr.py
++++ b/nova/tests/compute/test_compute_mgr.py
+@@ -1960,6 +1960,50 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
+ 
+         do_test()
+ 
++    def test_rebuild_default_impl(self):
++        def _detach(context, bdms):
++            pass
++
++        def _attach(context, instance, bdms, do_check_attach=True):
++            return {'block_device_mapping': 'shared_block_storage'}
++
++        def _spawn(context, instance, image_meta, injected_files,
++              admin_password, network_info=None, block_device_info=None):
++            self.assertEqual(block_device_info['block_device_mapping'],
++                             'shared_block_storage')
++
++        with contextlib.nested(
++            mock.patch.object(self.compute.driver, 'destroy',
++                              return_value=None),
++            mock.patch.object(self.compute.driver, 'spawn',
++                              side_effect=_spawn),
++            mock.patch.object(objects.Instance, 'save',
++                              return_value=None)
++        ) as(
++             mock_destroy,
++             mock_spawn,
++             mock_save
++        ):
++            instance = fake_instance.fake_instance_obj(self.context)
++            instance.task_state = task_states.REBUILDING
++            instance.save(expected_task_state=[task_states.REBUILDING])
++            self.compute._rebuild_default_impl(self.context,
++                                               instance,
++                                               None,
++                                               [],
++                                               admin_password='new_pass',
++                                               bdms=[],
++                                               detach_block_devices=_detach,
++                                               attach_block_devices=_attach,
++                                               network_info=None,
++                                               recreate=True,
++                                               block_device_info=None,
++                                               preserve_ephemeral=False)
++
++            self.assertFalse(mock_destroy.called)
++            self.assertTrue(mock_save.called)
++            self.assertTrue(mock_spawn.called)
++
+ 
+ class ComputeManagerBuildInstanceTestCase(test.NoDBTestCase):
+     def setUp(self):
+diff --git a/nova/tests/virt/libvirt/test_driver.py b/nova/tests/virt/libvirt/test_driver.py
+index 12a6156..0be5810 100644
+--- a/nova/tests/virt/libvirt/test_driver.py
++++ b/nova/tests/virt/libvirt/test_driver.py
+@@ -12591,6 +12591,17 @@ class LibvirtDriverTestCase(test.TestCase):
+                                vconfig.LibvirtConfigGuestGIDMap,
+                                1, 20000, 10)
+ 
++    def test_instance_on_disk(self):
++        conn = libvirt_driver.LibvirtDriver(fake.FakeVirtAPI(), False)
++        instance = objects.Instance(uuid='fake-uuid', id=1)
++        self.assertFalse(conn.instance_on_disk(instance))
++
++    def test_instance_on_disk_rbd(self):
++        self.flags(images_type='rbd', group='libvirt')
++        conn = libvirt_driver.LibvirtDriver(fake.FakeVirtAPI(), False)
++        instance = objects.Instance(uuid='fake-uuid', id=1)
++        self.assertTrue(conn.instance_on_disk(instance))
++
+ 
+ class LibvirtVolumeUsageTestCase(test.TestCase):
+     """Test for LibvirtDriver.get_all_volume_usage."""
+diff --git a/nova/virt/libvirt/driver.py b/nova/virt/libvirt/driver.py
+index dff1636..7750332 100644
+--- a/nova/virt/libvirt/driver.py
++++ b/nova/virt/libvirt/driver.py
+@@ -6452,7 +6452,13 @@ class LibvirtDriver(driver.ComputeDriver):
+         # ensure directories exist and are writable
+         instance_path = libvirt_utils.get_instance_path(instance)
+         LOG.debug('Checking instance files accessibility %s', instance_path)
+-        return os.access(instance_path, os.W_OK)
++        shared_instance_path = os.access(instance_path, os.W_OK)
++        # NOTE(flwang): For shared block storage scenario, the file system is
++        # not really shared by the two hosts, but the volume of evacuated
++        # instance is reachable.
++        shared_block_storage = (self.image_backend.backend().
++                                is_shared_block_storage())
++        return shared_instance_path or shared_block_storage
+ 
+     def inject_network_info(self, instance, nw_info):
+         self.firewall_driver.setup_basic_filtering(instance, nw_info)
+-- 
+2.4.3
+

--- a/packaging/openstack-nova/0035-Honor-shared-storage-on-resize-revert.patch
+++ b/packaging/openstack-nova/0035-Honor-shared-storage-on-resize-revert.patch
@@ -1,0 +1,186 @@
+From eaa5cd6ccc36fce523ef27d797575f95ef156aeb Mon Sep 17 00:00:00 2001
+From: Jon Bernard <jobernar@redhat.com>
+Date: Fri, 5 Dec 2014 11:58:12 -0500
+Subject: [PATCH 35/36] Honor shared storage on resize revert
+
+This patch improves the logic in resize_revert() to properly honor
+shared storage when destroying the unneeded instance.  In the case of
+shared storage, the disks need not be destroyed and doing so results in
+the inability to start the original instance.
+
+Conflicts is caused by moving tests to /unit directory
+
+Also commit contains squash from fixed implementation of determening
+if storage is shared (get from commit fde77d49ff550b73f5f1671edc7366c9b7646200)
+
+Conflicts:
+        nova/tests/unit/compute/test_compute.py
+        nova/tests/unit/compute/test_compute_mgr.py
+
+Closes-Bug: #1399244
+Change-Id: I310f6b62a790e4549a2cf9ff3842655da552177a
+(cherry picked from commit eec0937af9d88f3c7ffacf9ce7b8955b2e4be479)
+(cherry picked from commit b6692dd9f619de932ea9fc356da41ee1b471114c)
+
+NOTE(apporc): revert changes of 731e9200ed91a6122b3b71e7ac01be9bbc54b2fa.
+
+ Conflicts:
+	nova/compute/manager.py
+---
+ nova/compute/manager.py                |  9 +++--
+ nova/compute/rpcapi.py                 |  4 +--
+ nova/tests/compute/test_compute.py     |  4 ++-
+ nova/tests/compute/test_compute_mgr.py | 64 ++++++++++++++++++++++++++++++++++
+ 4 files changed, 73 insertions(+), 8 deletions(-)
+
+diff --git a/nova/compute/manager.py b/nova/compute/manager.py
+index b6d8436..82d0641 100644
+--- a/nova/compute/manager.py
++++ b/nova/compute/manager.py
+@@ -768,7 +768,7 @@ class ComputeManager(manager.Manager):
+                                     network_info,
+                                     bdi, destroy_disks)
+ 
+-    def _is_instance_storage_shared(self, context, instance):
++    def _is_instance_storage_shared(self, context, instance, host=None):
+         shared_storage = True
+         data = None
+         try:
+@@ -777,7 +777,7 @@ class ComputeManager(manager.Manager):
+             if data:
+                 shared_storage = (self.compute_rpcapi.
+                                   check_instance_shared_storage(context,
+-                                  instance, data))
++                                  instance, data, host=host))
+         except NotImplementedError:
+             LOG.warning(_('Hypervisor driver does not support '
+                           'instance shared storage check, '
+@@ -3510,9 +3510,8 @@ class ComputeManager(manager.Manager):
+             block_device_info = self._get_instance_block_device_info(
+                                 context, instance, bdms=bdms)
+ 
+-            # NOTE(apporc): ephemeral rbd root disk should not be deleted when
+-            # migrating, and by now it is not taken care of when resizing.
+-            destroy_disks = (CONF.libvirt.images_type != 'rbd')
++            destroy_disks = not self._is_instance_storage_shared(
++                context, instance, host=migration.source_compute)
+             self.driver.destroy(context, instance, network_info,
+                                 block_device_info, destroy_disks)
+ 
+diff --git a/nova/compute/rpcapi.py b/nova/compute/rpcapi.py
+index cc2d8e1..6ddba99 100644
+--- a/nova/compute/rpcapi.py
++++ b/nova/compute/rpcapi.py
+@@ -368,13 +368,13 @@ class ComputeAPI(object):
+                           instance=instance,
+                           dest_check_data=dest_check_data)
+ 
+-    def check_instance_shared_storage(self, ctxt, instance, data):
++    def check_instance_shared_storage(self, ctxt, instance, data, host=None):
+         if self.client.can_send_version('3.29'):
+             version = '3.29'
+         else:
+             version = '3.0'
+             instance = jsonutils.to_primitive(instance)
+-        cctxt = self.client.prepare(server=_compute_host(None, instance),
++        cctxt = self.client.prepare(server=_compute_host(host, instance),
+                 version=version)
+         return cctxt.call(ctxt, 'check_instance_shared_storage',
+                           instance=instance,
+diff --git a/nova/tests/compute/test_compute.py b/nova/tests/compute/test_compute.py
+index f4528a5..b3010e9 100644
+--- a/nova/tests/compute/test_compute.py
++++ b/nova/tests/compute/test_compute.py
+@@ -4266,6 +4266,8 @@ class ComputeTestCase(BaseTestCase):
+             self.context, objects.Instance(), instance,
+             expected_attrs=instance_obj.INSTANCE_DEFAULT_FIELDS)
+         for operation in actions:
++            if 'revert_resize' in operation:
++                migration.source_compute = 'fake-mini'
+             if operation[0] in want_objects:
+                 self._test_state_revert(inst_obj, *operation)
+             else:
+@@ -6610,7 +6612,7 @@ class ComputeTestCase(BaseTestCase):
+                 evacuated_instance).AndReturn({'filename': 'tmpfilename'})
+         self.compute.compute_rpcapi.check_instance_shared_storage(fake_context,
+                 evacuated_instance,
+-                {'filename': 'tmpfilename'}).AndReturn(False)
++                {'filename': 'tmpfilename'}, host=None).AndReturn(False)
+         self.compute.driver.check_instance_shared_storage_cleanup(fake_context,
+                 {'filename': 'tmpfilename'})
+         self.compute.driver.destroy(fake_context, evacuated_instance,
+diff --git a/nova/tests/compute/test_compute_mgr.py b/nova/tests/compute/test_compute_mgr.py
+index b4fa1b6..193265b 100644
+--- a/nova/tests/compute/test_compute_mgr.py
++++ b/nova/tests/compute/test_compute_mgr.py
+@@ -3060,3 +3060,67 @@ class ComputeManagerMigrationTestCase(test.NoDBTestCase):
+             )
+             self.assertEqual("error", self.migration.status)
+             migration_save.assert_has_calls([mock.call(elevated_context)])
++
++    @mock.patch.object(objects.InstanceActionEvent,
++                       'event_start')
++    @mock.patch.object(objects.InstanceActionEvent,
++                       'event_finish_with_failure')
++    def _test_revert_resize_instance_destroy_disks(self,
++                                                   event_finish,
++                                                   event_start,
++                                                   is_shared=False,):
++
++        # This test asserts that _is_instance_storage_shared() is called from
++        # revert_resize() and the return value is passed to driver.destroy().
++        # Otherwise we could regress this.
++
++        @mock.patch.object(self.compute, '_get_instance_nw_info')
++        @mock.patch.object(self.compute, '_is_instance_storage_shared')
++        @mock.patch.object(self.compute, 'finish_revert_resize')
++        @mock.patch.object(self.compute, '_instance_update')
++        @mock.patch.object(self.compute, '_get_resource_tracker')
++        @mock.patch.object(self.compute.driver, 'destroy')
++        @mock.patch.object(self.compute.network_api, 'setup_networks_on_host')
++        @mock.patch.object(self.compute.network_api, 'migrate_instance_start')
++        @mock.patch.object(self.compute.conductor_api, 'notify_usage_exists')
++        @mock.patch.object(self.migration, 'save')
++        @mock.patch.object(objects.BlockDeviceMappingList,
++                           'get_by_instance_uuid')
++        def do_test(get_by_instance_uuid,
++                    migration_save,
++                    notify_usage_exists,
++                    migrate_instance_start,
++                    setup_networks_on_host,
++                    destroy,
++                    _get_resource_tracker,
++                    _instance_update,
++                    finish_revert_resize,
++                    _is_instance_storage_shared,
++                    _get_instance_nw_info):
++
++            self.migration.source_compute = self.instance['host']
++
++            # Inform compute that instance uses non-shared or shared storage
++            _is_instance_storage_shared.return_value = is_shared
++
++            self.compute.revert_resize(context=self.context,
++                                       migration=self.migration,
++                                       instance=self.instance,
++                                       reservations=None)
++
++            _is_instance_storage_shared.assert_called_once_with(
++                self.context, self.instance,
++                host=self.migration.source_compute)
++
++            # If instance storage is shared, driver destroy method
++            # should not destroy disks otherwise it should destroy disks.
++            destroy.assert_called_once_with(self.context, self.instance,
++                                            mock.ANY, mock.ANY, not is_shared)
++
++        do_test()
++
++    def test_revert_resize_instance_destroy_disks_shared_storage(self):
++        self._test_revert_resize_instance_destroy_disks(is_shared=True)
++
++    def test_revert_resize_instance_destroy_disks_non_shared_storage(self):
++        self._test_revert_resize_instance_destroy_disks(is_shared=False)
+-- 
+2.4.3
+

--- a/packaging/openstack-nova/0036-eayunstack-channel.patch
+++ b/packaging/openstack-nova/0036-eayunstack-channel.patch
@@ -1,15 +1,16 @@
-From e956038795f67477cde31b80458329a573ca4950 Mon Sep 17 00:00:00 2001
+From 381a788f1288da0e04d9b04db7fe16ce3e38ee0b Mon Sep 17 00:00:00 2001
 From: apporc <appleorchard2000@gmail.com>
 Date: Mon, 27 Jul 2015 15:07:19 +0800
-Subject: [PATCH 32/34] eayunstack channel
+Subject: [PATCH 36/36] eayunstack channel
 
 Signed-off-by: apporc <appleorchard2000@gmail.com>
+(cherry picked from commit e956038795f67477cde31b80458329a573ca4950)
 ---
  nova/virt/libvirt/driver.py | 17 +++++++++++++++++
  1 file changed, 17 insertions(+)
 
 diff --git a/nova/virt/libvirt/driver.py b/nova/virt/libvirt/driver.py
-index ec0b1f5..a0ff8c6 100644
+index 7750332..25febdd 100644
 --- a/nova/virt/libvirt/driver.py
 +++ b/nova/virt/libvirt/driver.py
 @@ -4082,6 +4082,23 @@ class LibvirtDriver(driver.ComputeDriver):

--- a/packaging/openstack-nova/openstack-nova.spec
+++ b/packaging/openstack-nova/openstack-nova.spec
@@ -8,7 +8,7 @@
 
 Name:             openstack-nova
 Version:          2014.2
-Release:          7%{?dist_eayunstack}
+Release:          8%{?dist_eayunstack}
 Summary:          OpenStack Compute (nova)
 
 Group:            Applications/System
@@ -76,9 +76,11 @@ Patch0028: 0028-Add-setup-cleanup_instance_network_on_host-api-for-n.patch
 Patch0029: 0029-Update-network-resource-when-rescheduling-instance.patch
 Patch0030: 0030-Fix-nova-compute-start-issue-after-evacuate.patch
 Patch0031: 0031-output-log-to-nova-all-log-file.patch
-Patch0032: 0032-eayunstack-channel.patch
-Patch0033: 0033-network-fix-instance-cache-refresh-for-empty-list.patch
-Patch0034: 0034-fix-unicode-issue-in-vm-resuming-procedure.patch
+Patch0032: 0032-network-fix-instance-cache-refresh-for-empty-list.patch   
+Patch0033: 0033-fix-unicode-issue-in-vm-resuming-procedure.patch          
+Patch0034: 0034-Fix-nova-evacuate-issues-for-RBD.patch                    
+Patch0035: 0035-Honor-shared-storage-on-resize-revert.patch               
+Patch0036: 0036-eayunstack-channel.patch                                  
 
 BuildArch:        noarch
 BuildRequires:    intltool
@@ -515,6 +517,8 @@ This package contains documentation files for nova.
 %patch0032 -p1
 %patch0033 -p1
 %patch0034 -p1
+%patch0035 -p1
+%patch0036 -p1
 
 find . \( -name .gitignore -o -name .placeholder \) -delete
 
@@ -872,6 +876,15 @@ exit 0
 %endif
 
 %changelog
+* Tue Jan 19 2016 apporc <appleorchard2000@gmail.com> - 2014.2-8.eayunstack.1.1
+- delete patch 0032-eayunstack-channel.patch
+- delete patch 0033-network-fix-instance-cache-refresh-for-empty-list.patch
+- delete patch 0034-fix-unicode-issue-in-vm-resuming-procedure.patch
+- add patch 0032-network-fix-instance-cache-refresh-for-empty-list.patch   
+- add patch 0033-fix-unicode-issue-in-vm-resuming-procedure.patch          
+- add patch 0034-Fix-nova-evacuate-issues-for-RBD.patch                    
+- add patch 0035-Honor-shared-storage-on-resize-revert.patch               
+- add patch 0036-eayunstack-channel.patch                                  
 
 * Mon Jan 04 2016 apporc <appleorchard2000@gmail.com> - 2014.2-7.eayunstack.1.1
 - delete patch 0016-Add-setup-cleanup_instance_network_on_host-api-for-n.patch


### PR DESCRIPTION
…size

The order of commits is changed to sync with eayunstack-1.1 too. Because after eayunstack-1.1
is checkouted from eayunstack-1.0, eayunstack-1.0 is changed.

Signed-off-by: apporc appleorchard2000@gmail.com
