### PR TITLE
python-neutronclient: sync with master

### DIFF
--- a/packaging/python-neutronclient/0009-VPNaaS-deprecate-two-dpd-actions.patch
+++ b/packaging/python-neutronclient/0009-VPNaaS-deprecate-two-dpd-actions.patch
@@ -1,0 +1,66 @@
+From 39c2bf12b299015fa2efee314e5be5c532f68dd0 Mon Sep 17 00:00:00 2001
+From: Hunt Xu <mhuntxu@gmail.com>
+Date: Mon, 31 Oct 2016 14:00:31 +0800
+Subject: [PATCH] VPNaaS: deprecate two dpd actions
+
+Deprecate 'restart-by-peer' and 'disabled'.
+
+Fixes: redmine #8874
+
+Signed-off-by: Hunt Xu <mhuntxu@gmail.com>
+---
+ neutronclient/neutron/v2_0/vpn/utils.py    |  5 ++---
+ neutronclient/tests/unit/vpn/test_utils.py | 10 ----------
+ 2 files changed, 2 insertions(+), 13 deletions(-)
+
+diff --git a/neutronclient/neutron/v2_0/vpn/utils.py b/neutronclient/neutron/v2_0/vpn/utils.py
+index 832a6a2..d98bbc8 100644
+--- a/neutronclient/neutron/v2_0/vpn/utils.py
++++ b/neutronclient/neutron/v2_0/vpn/utils.py
+@@ -23,8 +23,7 @@
+ from neutronclient.common import exceptions
+ from neutronclient.openstack.common.gettextutils import _
+ 
+-dpd_supported_actions = ['hold', 'clear', 'restart',
+-                         'restart-by-peer', 'disabled']
++dpd_supported_actions = ['hold', 'clear', 'restart']
+ dpd_supported_keys = ['action', 'interval', 'timeout']
+ 
+ lifetime_keys = ['units', 'value']
+@@ -106,7 +105,7 @@ def lifetime_help(policy):
+ 
+ def dpd_help(policy):
+     dpd = _(" %s Dead Peer Detection attributes."
+-            " 'action'-hold,clear,disabled,restart,restart-by-peer."
++            " 'action'-hold,clear,restart."
+             " 'interval' and 'timeout' are non negative integers. "
+             " 'interval' should be less than 'timeout' value. "
+             " 'action', default:hold 'interval', default:30, "
+diff --git a/neutronclient/tests/unit/vpn/test_utils.py b/neutronclient/tests/unit/vpn/test_utils.py
+index 7b815a5..72d6c0b 100644
+--- a/neutronclient/tests/unit/vpn/test_utils.py
++++ b/neutronclient/tests/unit/vpn/test_utils.py
+@@ -36,20 +36,10 @@ class TestVPNUtils(testtools.TestCase):
+         input_str = utils.str2dict("action=restart,interval=30,timeout=120")
+         self.assertIsNone(vpn_utils.validate_dpd_dict(input_str))
+ 
+-    def test_validate_dpd_dictionary_action_restart_by_peer(self):
+-        input_str = utils.str2dict(
+-            "action=restart-by-peer,interval=30,timeout=120"
+-        )
+-        self.assertIsNone(vpn_utils.validate_dpd_dict(input_str))
+-
+     def test_validate_dpd_dictionary_action_clear(self):
+         input_str = utils.str2dict('action=clear,interval=30,timeout=120')
+         self.assertIsNone(vpn_utils.validate_dpd_dict(input_str))
+ 
+-    def test_validate_dpd_dictionary_action_disabled(self):
+-        input_str = utils.str2dict('action=disabled,interval=30,timeout=120')
+-        self.assertIsNone(vpn_utils.validate_dpd_dict(input_str))
+-
+     def test_validate_lifetime_dictionary_invalid_unit_key(self):
+         input_str = utils.str2dict('ut=seconds,value=3600')
+         self._test_validate_lifetime_negative_test_case(input_str)
+-- 
+2.10.2
+

--- a/packaging/python-neutronclient/python-neutronclient.spec
+++ b/packaging/python-neutronclient/python-neutronclient.spec
@@ -1,8 +1,8 @@
-%global dist_eayunstack .eayunstack.1.0.1
+%global dist_eayunstack .eayunstack.1.1
 
 Name:       python-neutronclient
 Version:    2.3.9
-Release:    4%{?dist_eayunstack}
+Release:    6%{?dist_eayunstack}
 Summary:    Python API and CLI for OpenStack Neutron
 
 Group:      Development/Languages
@@ -18,6 +18,8 @@ Patch0005: 0005-fix-the-firewall-rule-arg-split-error.patch
 Patch0006: 0006-Add-Portmapping-support.patch
 Patch0007: 0007-Add-pptp-vpn-credential-support.patch
 Patch0008: 0008-neutron-CLI-Add-support-lbaas-add-remove-command.patch
+Patch0009: 0009-VPNaaS-deprecate-two-dpd-actions.patch
+
 
 BuildArch:  noarch
 
@@ -49,6 +51,7 @@ Neutron's API.
 %patch0006 -p1
 %patch0007 -p1
 %patch0008 -p1
+%patch0009 -p1
 
 # We provide version like this in order to remove runtime dep on pbr.
 sed -i s/REDHATNEUTRONCLIENTVERSION/%{version}/ neutronclient/version.py
@@ -78,10 +81,15 @@ rm -rf %{buildroot}%{python_sitelib}/neutronclient/tests
 %{_sysconfdir}/bash_completion.d
 
 %changelog
-* Fri Oct 21 2016 Xu Meihong <meihong.xu@eayun.com> 2.3.9-4.eayunstack.1.0.1
-- add 0006-Add-Portmapping-support.patch
-- add 0007-Add-pptp-vpn-credential-support.patch
+* Wed Nov 02 2016 Xu Meihong <meihong.xu@eayun.com> 2.3.9-6.eayunstack.1.1
+- add 0009-VPNaaS-deprecate-two-dpd-actions.patch (redmine#8874)
+
+* Tue Jul 26 2016 Tang Cheng <cheng.tang@eayun.com> 2.3.9-5.eayunstack.1.1
 - add 0008-neutron-CLI-Add-support-lbaas-add-remove-command.patch (redmine#7581)
+
+* Mon Dec 21 2015 Xu Meihong <meihong.xu@eayun.com> 2.3.9-4.eayunstack.1.1
+- add 0006-Add-Portmapping-support.patch from github pull request #6 (redmine#4553)
+- add 0007-Add-pptp-vpn-credential-support.patch from github pull request #7
 
 * Thu May 21 2015 Xu Meihong <meihong.xu@eayun.com> 2.3.9-3.eayunstack.1.0
 - add 0005-fix-the-firewall-rule-arg-split-error.patch (redmine#3720)


### PR DESCRIPTION
It is not needed to track two different versions of
python-neutronclient.

Signed-off-by: Hunt Xu <mhuntxu@gmail.com>