### PR TITLE
openstack-nova: 2014.2-7.3.eayunstack

### DIFF
--- a/packaging/openstack-nova/0041-Handle-exception-when-doing-detach_interface.patch
+++ b/packaging/openstack-nova/0041-Handle-exception-when-doing-detach_interface.patch
@@ -1,0 +1,89 @@
+From 139e1e78d5a163adf922678d44550ea602d09833 Mon Sep 17 00:00:00 2001
+From: blkart <blkart.org@gmail.com>
+Date: Thu, 24 Aug 2017 18:34:45 +0800
+Subject: [PATCH 1/3] Handle exception when doing detach_interface
+
+Currently, in compute api, detach_interface will delete neutron port
+first then calls hypervisor driver to do detach_interface on the guest.
+If the driver does detach_interface failed, in case of the driver raise
+an exception.InterfaceDetachFailed or other NovaExceptions, there is no
+handler for them.
+Besides this is an asyn rpc call, so nova-api will not notice these
+exceptions. End user will find the port has been deleted in neutron side,
+but still can see this port on guest, this is inconsistent.
+
+This patch moves delete port in neturon side after hypervisor finished
+detach_interface successfully, if it catch NovaException,
+gives a log warning, and keep this port in neutron.
+
+Change-Id: Ie376c211093f63a4b3f3837267c74502bd34a192
+Closes-Bug: #1432465
+
+Related Upstream Commit: 92f986d9c8d982afa6f6d1fa2df281c8a2305a4c
+
+Signed-off-by: blkart <blkart.org@gmail.com>
+(cherry picked from commit 6598e62cbcfdecf76e1281bd00caf5f41176e133)
+---
+ nova/compute/manager.py            | 14 ++++++++++----
+ nova/tests/compute/test_compute.py | 20 ++++++++++++++++++++
+ 2 files changed, 30 insertions(+), 4 deletions(-)
+
+diff --git a/nova/compute/manager.py b/nova/compute/manager.py
+index a5008dd..16a9eab 100644
+--- a/nova/compute/manager.py
++++ b/nova/compute/manager.py
+@@ -4921,10 +4921,16 @@ class ComputeManager(manager.Manager):
+         if condemned is None:
+             raise exception.PortNotFound(_("Port %s is not "
+                                            "attached") % port_id)
+-
+-        self.network_api.deallocate_port_for_instance(context, instance,
+-                                                      port_id)
+-        self.driver.detach_interface(instance, condemned)
++        try:
++            self.driver.detach_interface(instance, condemned)
++        except exception.NovaException as ex:
++            LOG.warning(_LW("Detach interface failed, port_id=%(port_id)s,"
++                            " reason: %(msg)s"),
++                        {'port_id': port_id, 'msg': ex}, instance=instance)
++            raise exception.InterfaceDetachFailed(instance_uuid=instance.uuid)
++        else:
++            self.network_api.deallocate_port_for_instance(context, instance,
++                                                          port_id)
+ 
+     def _get_compute_info(self, context, host):
+         service = objects.Service.get_by_compute_host(context, host)
+diff --git a/nova/tests/compute/test_compute.py b/nova/tests/compute/test_compute.py
+index 48aba6b..b0a92a1 100644
+--- a/nova/tests/compute/test_compute.py
++++ b/nova/tests/compute/test_compute.py
+@@ -9192,6 +9192,26 @@ class ComputeAPITestCase(BaseTestCase):
+         self.compute.detach_interface(self.context, instance, port_id)
+         self.assertEqual(self.compute.driver._interfaces, {})
+ 
++    def test_detach_interface_failed(self):
++        nwinfo, port_id = self.test_attach_interface()
++        instance = objects.Instance()
++        instance['uuid'] = 'fake-uuid'
++        instance.info_cache = objects.InstanceInfoCache.new(
++            self.context, 'fake-uuid')
++        instance.info_cache.network_info = network_model.NetworkInfo.hydrate(
++            nwinfo)
++
++        with contextlib.nested(
++            mock.patch.object(self.compute.driver, 'detach_interface',
++                side_effect=exception.NovaException('detach_failed')),
++            mock.patch.object(self.compute.network_api,
++                              'deallocate_port_for_instance')) as (
++            mock_detach, mock_deallocate):
++            self.assertRaises(exception.InterfaceDetachFailed,
++                              self.compute.detach_interface, self.context,
++                              instance, port_id)
++            self.assertFalse(mock_deallocate.called)
++
+     def test_attach_volume(self):
+         fake_bdm = fake_block_device.FakeDbBlockDeviceDict(
+                 {'source_type': 'volume', 'destination_type': 'volume',
+-- 
+2.1.0
+

--- a/packaging/openstack-nova/0042-Log-exception-from-deallocate_port_for_instance-for-.patch
+++ b/packaging/openstack-nova/0042-Log-exception-from-deallocate_port_for_instance-for-.patch
@@ -1,0 +1,103 @@
+From 9c4e1a50a8bb5d6cd0655973e43a7eda49f6257f Mon Sep 17 00:00:00 2001
+From: blkart <blkart.org@gmail.com>
+Date: Thu, 24 Aug 2017 19:02:17 +0800
+Subject: [PATCH 2/3] Log exception from deallocate_port_for_instance for
+ triage
+
+detach_interface is a cast operation and sometimes
+NeutronClientExceptions slip through the neutronv2 API, so let's be sure
+to log any exceptions that come up from the network API method so we can
+triage them later.
+
+Related-Bug: #1326183
+
+Change-Id: I1e96128b8a502b32d1e651101d9bfd606ed4855b
+
+Related Upstream Commit: 3244063a5cabd76a4651df8c0d8ff496ffc465d4
+
+Upstream-Fixed
+
+Signed-off-by: blkart <blkart.org@gmail.com>
+(cherry picked from commit da7e83a37c461f71ae9ab3dc09c3e2d3dab85cbf)
+---
+ nova/compute/manager.py            | 13 +++++++++++--
+ nova/tests/compute/test_compute.py | 32 ++++++++++++++++++++++++++++++++
+ 2 files changed, 43 insertions(+), 2 deletions(-)
+
+diff --git a/nova/compute/manager.py b/nova/compute/manager.py
+index 16a9eab..c0f4886 100644
+--- a/nova/compute/manager.py
++++ b/nova/compute/manager.py
+@@ -4929,8 +4929,17 @@ class ComputeManager(manager.Manager):
+                         {'port_id': port_id, 'msg': ex}, instance=instance)
+             raise exception.InterfaceDetachFailed(instance_uuid=instance.uuid)
+         else:
+-            self.network_api.deallocate_port_for_instance(context, instance,
+-                                                          port_id)
++            try:
++                self.network_api.deallocate_port_for_instance(
++                    context, instance, port_id)
++            except Exception as ex:
++                with excutils.save_and_reraise_exception():
++                    # Since this is a cast operation, log the failure for
++                    # triage.
++                    LOG.warning(_LW('Failed to deallocate port %(port_id)s '
++                                    'for instance. Error: %(error)s'),
++                                {'port_id': port_id, 'error': ex},
++                                instance=instance)
+ 
+     def _get_compute_info(self, context, host):
+         service = objects.Service.get_by_compute_host(context, host)
+diff --git a/nova/tests/compute/test_compute.py b/nova/tests/compute/test_compute.py
+index b0a92a1..6518f76 100644
+--- a/nova/tests/compute/test_compute.py
++++ b/nova/tests/compute/test_compute.py
+@@ -29,6 +29,7 @@ import uuid
+ from eventlet import greenthread
+ import mock
+ import mox
++from neutronclient.common import exceptions as neutron_exceptions
+ from oslo.config import cfg
+ from oslo import messaging
+ from oslo.utils import timeutils as db_timeutils
+@@ -9212,6 +9213,37 @@ class ComputeAPITestCase(BaseTestCase):
+                               instance, port_id)
+             self.assertFalse(mock_deallocate.called)
+ 
++    @mock.patch.object(compute_manager.LOG, 'warning')
++    def test_detach_interface_deallocate_port_for_instance_failed(self,
++                                                                  warn_mock):
++        # Tests that when deallocate_port_for_instance fails we log the failure
++        # before exiting compute.detach_interface.
++        nwinfo, port_id = self.test_attach_interface()
++        instance = objects.Instance(uuid=uuidutils.generate_uuid())
++        instance.info_cache = objects.InstanceInfoCache.new(
++            self.context, 'fake-uuid')
++        instance.info_cache.network_info = network_model.NetworkInfo.hydrate(
++            nwinfo)
++
++        # Sometimes neutron errors slip through the neutronv2 API so we want
++        # to make sure we catch those in the compute manager and not just
++        # NovaExceptions.
++        error = neutron_exceptions.PortNotFoundClient()
++        with contextlib.nested(
++            mock.patch.object(self.compute.driver, 'detach_interface'),
++            mock.patch.object(self.compute.network_api,
++                              'deallocate_port_for_instance',
++                              side_effect=error),
++            mock.patch.object(self.compute, '_instance_update')) as (
++            mock_detach, mock_deallocate, mock_instance_update):
++            ex = self.assertRaises(neutron_exceptions.PortNotFoundClient,
++                                   self.compute.detach_interface, self.context,
++                                   instance, port_id)
++            self.assertEqual(error, ex)
++        mock_deallocate.assert_called_once_with(
++            self.context, instance, port_id)
++        self.assertEqual(1, warn_mock.call_count)
++
+     def test_attach_volume(self):
+         fake_bdm = fake_block_device.FakeDbBlockDeviceDict(
+                 {'source_type': 'volume', 'destination_type': 'volume',
+-- 
+2.1.0
+

--- a/packaging/openstack-nova/0043-Refresh-instance-info-cache-within-lock.patch
+++ b/packaging/openstack-nova/0043-Refresh-instance-info-cache-within-lock.patch
@@ -1,0 +1,99 @@
+From d4053cc07b08dc9b8b703c814ab553b495d283d7 Mon Sep 17 00:00:00 2001
+From: blkart <blkart.org@gmail.com>
+Date: Thu, 24 Aug 2017 19:42:03 +0800
+Subject: [PATCH 3/3] Refresh instance info cache within lock
+
+Fix interface attachment bug where multiple concurrent attachment
+requests can cause corruption of the nova instance info cache. This
+change refreshes the info cache object from the database whilst
+holding the refresh-cache lock, ensuring that changes are
+synchronised.
+
+Change-Id: I6ea2eda8a61f418b0c32f13a7ed6904352712857
+Closes-Bug: #1467581
+
+Related Upstream Commit: 0fb97014689b1b9575cafae88447db7f86ff4292
+
+Signed-off-by: blkart <blkart.org@gmail.com>
+(cherry picked from commit 8f7b1526f2213e674433c19ed07af05329ba3bdb)
+---
+ nova/compute/utils.py                                            | 9 +++++++++
+ nova/network/base_api.py                                         | 4 +++-
+ nova/network/neutronv2/api.py                                    | 4 ++++
+ .../openstack/compute/contrib/test_neutron_security_groups.py    | 3 ++-
+ 4 files changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/nova/compute/utils.py b/nova/compute/utils.py
+index ce761d8..2164b8d 100644
+--- a/nova/compute/utils.py
++++ b/nova/compute/utils.py
+@@ -405,6 +405,15 @@ def finish_instance_usage_audit(context, conductor, begin, end, host, errors,
+                                 host, errors, message)
+ 
+ 
++def refresh_info_cache_for_instance(context, instance):
++    """Refresh the info cache for an instance.
++
++    :param instance: The instance object.
++    """
++    if instance.info_cache is not None:
++        instance.info_cache.refresh()
++
++
+ def usage_volume_info(vol_usage):
+     def null_safe_str(s):
+         return str(s) if s else ''
+diff --git a/nova/network/base_api.py b/nova/network/base_api.py
+index beeaa48..5f42a9c 100644
+--- a/nova/network/base_api.py
++++ b/nova/network/base_api.py
+@@ -58,7 +58,6 @@ def refresh_cache(f):
+ 
+     @functools.wraps(f)
+     def wrapper(self, context, *args, **kwargs):
+-        res = f(self, context, *args, **kwargs)
+         try:
+             # get the instance from arguments (or raise ValueError)
+             instance = kwargs.get('instance')
+@@ -69,6 +68,9 @@ def refresh_cache(f):
+             raise Exception(msg)
+ 
+         with lockutils.lock('refresh_cache-%s' % instance['uuid']):
++            # We need to call the wrapped function with the lock held to ensure
++            # that it can call _get_instance_nw_info safely.
++            res = f(self, context, *args, **kwargs)
+             update_instance_cache_with_nw_info(self, context, instance,
+                                                nw_info=res)
+         # return the original function's return value
+diff --git a/nova/network/neutronv2/api.py b/nova/network/neutronv2/api.py
+index 9178930..82afcf2 100644
+--- a/nova/network/neutronv2/api.py
++++ b/nova/network/neutronv2/api.py
+@@ -609,6 +609,10 @@ class API(base_api.NetworkAPI):
+         # by other code that updates instance nwinfo. It *must* be
+         # called with the refresh_cache-%(instance_uuid) lock held!
+         LOG.debug('get_instance_nw_info()', instance=instance)
++        # Ensure that we have an up to date copy of the instance info cache.
++        # Otherwise multiple requests could collide and cause cache
++        # corruption.
++        compute_utils.refresh_info_cache_for_instance(context, instance)
+         nw_info = self._build_network_info_model(context, instance, networks,
+                                                  port_ids)
+         return network_model.NetworkInfo.hydrate(nw_info)
+diff --git a/nova/tests/api/openstack/compute/contrib/test_neutron_security_groups.py b/nova/tests/api/openstack/compute/contrib/test_neutron_security_groups.py
+index 654d635..14eb8da 100644
+--- a/nova/tests/api/openstack/compute/contrib/test_neutron_security_groups.py
++++ b/nova/tests/api/openstack/compute/contrib/test_neutron_security_groups.py
+@@ -177,7 +177,8 @@ class TestNeutronSecurityGroups(
+                                       sg['id'], use_admin_context=True)
+         self.controller.delete(req, sg['id'])
+ 
+-    def test_delete_security_group_in_use(self):
++    @mock.patch('nova.compute.utils.refresh_info_cache_for_instance')
++    def test_delete_security_group_in_use(self, refresh_info_cache_mock):
+         sg = self._create_sg_template().get('security_group')
+         self._create_network()
+         db_inst = fakes.stub_instance(id=1, nw_cache=[], security_groups=[])
+-- 
+2.1.0
+

--- a/packaging/openstack-nova/openstack-nova.spec
+++ b/packaging/openstack-nova/openstack-nova.spec
@@ -8,7 +8,7 @@
 
 Name:             openstack-nova
 Version:          2014.2
-Release:          7.2%{?dist_eayunstack}
+Release:          7.3%{?dist_eayunstack}
 Summary:          OpenStack Compute (nova)
 
 Group:            Applications/System
@@ -85,6 +85,9 @@ Patch0037: 0037-Replace-root-volume-during-rebuild.patch
 Patch0038: 0038-rebuild-make-sure-server-is-shut-down-before-volumes.patch
 Patch0039: 0039-Libvirt-connect-to-libvirt-network-for-PaaS-instance.patch
 Patch0040: 0040-Libvirt-register-config-opt-es_paas_network.patch
+Patch0041: 0041-Handle-exception-when-doing-detach_interface.patch
+Patch0042: 0042-Log-exception-from-deallocate_port_for_instance-for-.patch
+Patch0043: 0043-Refresh-instance-info-cache-within-lock.patch
 
 
 BuildArch:        noarch
@@ -528,6 +531,9 @@ This package contains documentation files for nova.
 %patch0038 -p1
 %patch0039 -p1
 %patch0040 -p1
+%patch0041 -p1
+%patch0042 -p1
+%patch0043 -p1
 
 find . \( -name .gitignore -o -name .placeholder \) -delete
 
@@ -885,6 +891,11 @@ exit 0
 %endif
 
 %changelog
+* Fri Aug 25 2017 blkart <blkart.org@gmail.com> - 2014.2-7.3.eayunstack
+- 0041-Handle-exception-when-doing-detach_interface.patch
+- 0042-Log-exception-from-deallocate_port_for_instance-for-.patch
+- 0043-Refresh-instance-info-cache-within-lock.patch
+
 * Fri Aug 4 2017 dwong <peng.wang@eayun.com> - 2014.2-7.2.eayunstack
 - 0039-Libvirt-connect-to-libvirt-network-for-PaaS-instance.patch
 - 0040-Libvirt-register-config-opt-es_paas_network.patch


### PR DESCRIPTION
- 0041-Handle-exception-when-doing-detach_interface.patch
- 0042-Log-exception-from-deallocate_port_for_instance-for-.patch
- 0043-Refresh-instance-info-cache-within-lock.patch

Signed-off-by: blkart <blkart.org@gmail.com>